### PR TITLE
(MAINT) Update ruby version in binary paths

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,8 +13,8 @@ RUN ["./install-pdk-release.sh"]
 RUN apt-get remove -y curl && \
     apt-get autoremove -y && \
     rm -rf /var/lib/apt/lists/* && \
-    /opt/puppetlabs/pdk/private/ruby/2.4.5/bin/gem install --no-document onceover && \
-    ln -s /opt/puppetlabs/pdk/private/ruby/2.4.5/bin/onceover /usr/local/bin/onceover
+    /opt/puppetlabs/pdk/private/ruby/2.4.9/bin/gem install --no-document onceover && \
+    ln -s /opt/puppetlabs/pdk/private/ruby/2.4.9/bin/onceover /usr/local/bin/onceover
 
 ENV PATH="${PATH}:/opt/puppetlabs/pdk/private/git/bin"
 


### PR DESCRIPTION
The `docker build` command was failing with a previously-included version of Ruby in the binary paths.