### PR TITLE
(PF-1879) Add initial anubis Dockerfile and puppet-strings entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,11 +10,11 @@ ADD install-onceover.sh .
 ADD pdk-release.env .
 
 RUN ["./install-pdk-release.sh"]
+RUN ["./install-onceover.sh"]
 
 RUN apt-get remove -y curl && \
     apt-get autoremove -y && \
     rm -rf /var/lib/apt/lists/* && \
-    ./install-onceover.sh && \
     rm install-pdk-release.sh install-onceover.sh
 
 ENV PATH="${PATH}:/opt/puppetlabs/pdk/private/git/bin"

--- a/anubis/Dockerfile
+++ b/anubis/Dockerfile
@@ -1,0 +1,28 @@
+FROM ubuntu:bionic
+
+RUN apt-get update && \
+    apt-get install -y curl
+
+WORKDIR /root
+
+ADD install-pdk-release.sh .
+ADD pdk-release.env .
+
+RUN ["./install-pdk-release.sh"]
+
+RUN apt-get autoremove -y && \
+    rm -rf /var/lib/apt/lists/* && \
+    rm install-pdk-release.sh
+
+RUN ["useradd", "--create-home", "--home-dir", "/anubis", "--shell", "/bin/bash", "--user-group", "anubis"]
+USER anubis
+
+ENV PATH="${PATH}:/opt/puppetlabs/pdk/private/git/bin"
+ENV PDK_DISABLE_ANALYTICS=true
+
+WORKDIR /anubis
+
+RUN ["mkdir", "-p", "entrypoints", "shared", "workspace"]
+
+ADD anubis/entrypoints entrypoints/
+ADD anubis/shared shared/

--- a/anubis/entrypoints/puppet-strings
+++ b/anubis/entrypoints/puppet-strings
@@ -1,0 +1,31 @@
+#!/bin/bash
+set -e
+
+# Establish source dir for relative includes
+DIR="${BASH_SOURCE%/*}"
+if [[ ! -d "$DIR" ]]; then DIR="$PWD"; fi
+
+# Pre-suite (download and extract requested release)
+# shellcheck source=../shared/entrypoint-pre disable=SC1091
+. "$DIR/../shared/entrypoint-pre"
+
+# Make sure required Anubis env vars are set
+# shellcheck source=../shared/entrypoint-anubis-pre disable=SC1091
+. "$DIR/../shared/entrypoint-anubis-pre"
+
+# TODO make a PDK frontend/backdoor for this? like a wrapper in /opt/puppetlabs/pdk/private?
+export PATH=$PATH:/opt/puppetlabs/pdk/private/ruby/2.5.7/bin
+export GEM_PATH=/opt/puppetlabs/pdk/private/ruby/2.5.7/lib/ruby/gems/2.5.0:/opt/puppetlabs/pdk/share/cache/ruby/2.5.0:/opt/puppetlabs/pdk/private/puppet/ruby/2.5.0
+
+# Run strings and emit output to json document
+/opt/puppetlabs/pdk/private/puppet/ruby/2.5.0/bin/puppet strings generate --format json | tee anubis_output.json
+
+# Post results back to given API endpoint
+# shellcheck source=../shared/entrypoint-anubis-post disable=SC1091
+. "$DIR/../shared/entrypoint-anubis-post"
+
+# shellcheck source=shared/entrypoint-post disable=SC1091
+. "$DIR/../shared/entrypoint-post"
+
+exit 0
+

--- a/anubis/shared/entrypoint-anubis-post
+++ b/anubis/shared/entrypoint-anubis-post
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# Post results back to specified URI
+curl \
+  --fail \
+  --progress-bar \
+  --request PATCH \
+  --header "Authorization: Bearer ${WEBHOOK_TOKEN}" \
+  --data-urlencode content@anubis_output.json \
+  "${WEBHOOK_URI}"

--- a/anubis/shared/entrypoint-anubis-pre
+++ b/anubis/shared/entrypoint-anubis-pre
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# WEBHOOK_URI: full URI to post results back to, no default
+# WEBHOOK_TOKEN: unique token to authenticate webhook request, no default
+
+# Check for required env vars
+: "${WEBHOOK_URI:?Need to set WEBHOOK_URI}"
+: "${WEBHOOK_TOKEN:?Need to set WEBHOOK_TOKEN}"

--- a/anubis/shared/entrypoint-post
+++ b/anubis/shared/entrypoint-post
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+popd > /dev/null || exit
+popd > /dev/null || exit

--- a/anubis/shared/entrypoint-pre
+++ b/anubis/shared/entrypoint-pre
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+# Check for required args
+: "${1:?Please provide a module release slug (e.g. puppetlabs-apache-1.0.0) as the first argument}"
+# TODO: add format as an available arg?
+
+# TODO: check if release slug matches regex and exit if not
+
+release_slug="$1"
+
+# Check for custom download URI or use default
+if [[ -z "${RELEASE_URI}" ]]; then
+  # TODO: write this to stderr
+  #echo "DEBUG: RELEASE_URI not set, using default..."
+  download_uri="https://forgeapi.puppet.com/v3/files/${release_slug}.tar.gz"
+else
+  download_uri=${RELEASE_URI}
+fi
+
+pushd workspace > /dev/null || exit
+
+# Download and extract module release
+curl -sS -O "${download_uri}"
+
+# TODO: check if URL existed/download succeeded
+
+tar -xzf "${release_slug}.tar.gz"
+
+# Change to the module root by finding the first instance of metadata.json
+pushd -- "$(find . -name "metadata.json" -type f -printf '%h' -quit)" > /dev/null || exit


### PR DESCRIPTION
This commit adds a new Anubis-specific Dockerfile which shares a lot of
characteristics from the main Dockerfile. There is a little bit of code
duplication but not too much since the PDK installation step is already
done in a shell script.

This commit also adds some shared "pre" and "post" shell scripts in
`anubis/shared` which implement things that will need to happen for most
module evaluation tasks. For example, the `anubis/shared/entrypoint-pre`
script handles downloading a specific module release from the Forge API,
unpacking it, and then finding the "root" of the module by searching for
a `metadata.json` file.

Similarly the `anubis/shared/entrypoint-anubis-post` script handles
submitting a `PATCH` request back to the Forge API that includes the
passed-in auth token in an `Authorization` header and the contents of
`anubis_output.json` url-encoded into a form field.

Lastly, this commit adds an initial `anubis/entrypoints/puppet-strings`
entrypoint script to handle the specific task of running
`puppet-strings` on a given module release with all the appropriate
"pre" and "post" scripts called in the correct order.

Dockerfile usage example is then something like this:

```
docker run --entrypoint=/anubis/entrypoints/puppet-strings -e
WEBHOOK_URI=http://example.com/private/evaluations -e WEBHOOK_TOKEN=abc123
pdk-anubis:latest puppetlabs-motd-3.1.0
```