### PR TITLE
Correct layer misuse

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,18 @@
 FROM ubuntu:bionic
 
-RUN apt-get update && \
-    apt-get install -y curl
-
 WORKDIR /root
 
 ADD install-pdk-release.sh .
 ADD install-onceover.sh .
 ADD pdk-release.env .
 
-RUN ["./install-pdk-release.sh"]
-RUN ["./install-onceover.sh"]
-
-RUN apt-get remove -y curl && \
+RUN apt-get update && \
+    apt-get install -y curl && \
+    ./install-pdk-release.sh && \
+    ./install-onceover.sh && \
+    apt-get purge -y curl && \
     apt-get autoremove -y && \
-    rm -rf /var/lib/apt/lists/* && \
-    rm install-pdk-release.sh install-onceover.sh
+    rm -rf /var/lib/apt/lists/*
 
 ENV PATH="${PATH}:/opt/puppetlabs/pdk/private/git/bin"
 ENV PDK_DISABLE_ANALYTICS=true


### PR DESCRIPTION
Removing files from a previous layer is ineffective. Optimising the dockerfile to prevent the apt cache from being committed to the image; also use `apt-get purge` rather than `apt-get remove` to fully remove curl after use (again, without it being committed to a layer). Removed the unnecessary removal of the installation script files, since they remain in the image layers anyway.