### PR TITLE
(PF-2226) Add github workflow for building & pushing Docker images

### DIFF
--- a/.github/workflows/image-push.yml
+++ b/.github/workflows/image-push.yml
@@ -1,0 +1,82 @@
+name: image-push
+
+on:
+  push:
+    branches:
+      - master
+      - stable
+    tags:
+      - '[0-9]+.*'
+
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Set tag to nightly
+        if: endsWith(github.ref, '/master')
+        run: |
+          echo "PDK_TAG=nightly" >> $GITHUB_ENV
+          echo "ANUBIS_TAG=anubis-nightly" >> $GITHUB_ENV
+      -
+        name: Set tag to stable or latest
+        if: endsWith(github.ref, '/stable')
+        run: |
+          echo "PDK_TAG=latest" >> $GITHUB_ENV
+          echo "ANUBIS_TAG=anubis-stable" >> $GITHUB_ENV
+      -
+        name: Set tag to git tag name
+        if: startsWith(github.ref, 'refs/tags/')
+        run: |
+          echo "PDK_TAG=${GITHUB_REF##*/}" >> $GITHUB_ENV
+      -
+        name: Checkout
+        uses: actions/checkout@v2
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      -
+        name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      -
+        name: Login to ECR
+        id: login_ecr
+        uses: docker/login-action@v1
+        with:
+          registry: ${{ secrets.AWS_FORGE_ID }}.dkr.ecr.us-west-2.amazonaws.com
+          username: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          password: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      -
+        name: Build and push Anubis
+        # Only push branches for Anubis, not git tags
+        if: startsWith(github.ref, 'refs/tags/') == false
+        id: docker_build_anubis
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./anubis/Dockerfile
+          push: true
+          tags: |
+            ${{ secrets.AWS_FORGE_ID }}.dkr.ecr.us-west-2.amazonaws.com/anubis:${{ env.ANUBIS_TAG }}
+            puppet/pdk:${{ env.ANUBIS_TAG }}
+      -
+        name: Build and push PDK
+        id: docker_build_pdk
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: true
+          tags: |
+            ${{ secrets.AWS_FORGE_ID }}.dkr.ecr.us-west-2.amazonaws.com/anubis:${{ env.PDK_TAG }}
+            puppet/pdk:${{ env.PDK_TAG }}
+      -
+        name: Image digest
+        run: |
+          echo 'Anubis: ${{ steps.docker_build_anubis.outputs.digest }}'
+          echo 'PDK: ${{ steps.docker_build_pdk.outputs.digest }}'


### PR DESCRIPTION
Adds a workflow for building & pushing both PDK and Anubis images to Dockerhub & ECR, recreating the existing build configuration from Dockerhub's autobuild.