### PR TITLE
(PF-2215) Add entrypoint for Anubis lint evaluation

### DIFF
--- a/anubis/entrypoints/puppet-lint
+++ b/anubis/entrypoints/puppet-lint
@@ -1,0 +1,32 @@
+#!/bin/bash
+set -e
+
+# Establish source dir for relative includes
+DIR="${BASH_SOURCE%/*}"
+if [[ ! -d "$DIR" ]]; then DIR="$PWD"; fi
+
+# Pre-suite (download and extract requested release)
+# shellcheck source=../shared/entrypoint-pre disable=SC1091
+. "$DIR/../shared/entrypoint-pre"
+
+# Make sure required Anubis env vars are set
+# shellcheck source=../shared/entrypoint-anubis-pre disable=SC1091
+. "$DIR/../shared/entrypoint-anubis-pre"
+
+# TODO make a PDK frontend/backdoor for this? like a wrapper in /opt/puppetlabs/pdk/private?
+export PATH=$PATH:/opt/puppetlabs/pdk/private/ruby/2.5.8/bin:/opt/puppetlabs/pdk/private/ruby/2.5.8/lib/ruby/gems/2.5.0
+export GEM_PATH=/opt/puppetlabs/pdk/private/ruby/2.5.8/lib/ruby/gems/2.5.0:/opt/puppetlabs/pdk/share/cache/ruby/2.5.0:/opt/puppetlabs/pdk/private/puppet/ruby/2.5.0
+
+# Run lint and emit output to json document
+/opt/puppetlabs/pdk/share/cache/ruby/2.5.0/bin/puppet-lint --json manifests > anubis_output.json
+cat anubis_output.json
+
+# Post results back to given API endpoint
+# shellcheck source=../shared/entrypoint-anubis-post disable=SC1091
+. "$DIR/../shared/entrypoint-anubis-post"
+
+# shellcheck source=shared/entrypoint-post disable=SC1091
+. "$DIR/../shared/entrypoint-post"
+
+exit 0
+

--- a/anubis/entrypoints/puppet-strings
+++ b/anubis/entrypoints/puppet-strings
@@ -14,8 +14,8 @@ if [[ ! -d "$DIR" ]]; then DIR="$PWD"; fi
 . "$DIR/../shared/entrypoint-anubis-pre"
 
 # TODO make a PDK frontend/backdoor for this? like a wrapper in /opt/puppetlabs/pdk/private?
-export PATH=$PATH:/opt/puppetlabs/pdk/private/ruby/2.5.7/bin
-export GEM_PATH=/opt/puppetlabs/pdk/private/ruby/2.5.7/lib/ruby/gems/2.5.0:/opt/puppetlabs/pdk/share/cache/ruby/2.5.0:/opt/puppetlabs/pdk/private/puppet/ruby/2.5.0
+export PATH=$PATH:/opt/puppetlabs/pdk/private/ruby/2.5.8/bin
+export GEM_PATH=/opt/puppetlabs/pdk/private/ruby/2.5.8/lib/ruby/gems/2.5.0:/opt/puppetlabs/pdk/share/cache/ruby/2.5.0:/opt/puppetlabs/pdk/private/puppet/ruby/2.5.0
 
 # Run strings and emit output to json document
 /opt/puppetlabs/pdk/private/puppet/ruby/2.5.0/bin/puppet strings generate --format json --out anubis_output.json


### PR DESCRIPTION
Largely duplicates the puppet-strings entrypoint, with updates to the ruby environment and the command invocation, since puppet-lint exists as a gem rather than a puppet subcommand.