### PR TITLE
(FIXUP) Add additional error handling for Anubis v2 evaluations

### DIFF
--- a/anubis/entrypoints/puppet-lint
+++ b/anubis/entrypoints/puppet-lint
@@ -16,21 +16,27 @@ if [[ ! -d "$DIR" ]]; then DIR="$PWD"; fi
 manifests=0
 lines=0
 
-for f in $(find manifests -type f -name "*.pp")
-do
-  manifests=$((manifests+1))
-  lines=$(($lines + $(wc -l < $f)))
-done
+if [ -d "manifests" ]; then
+  for f in $(find manifests -type f -name "*.pp")
+  do
+    manifests=$((manifests+1))
+    lines=$(($lines + $(wc -l < $f)))
+  done
+fi
 
 # TODO make a PDK frontend/backdoor for this? like a wrapper in /opt/puppetlabs/pdk/private?
 export PATH=$PATH:/opt/puppetlabs/pdk/private/ruby/2.5.8/bin:/opt/puppetlabs/pdk/private/ruby/2.5.8/lib/ruby/gems/2.5.0
 export GEM_PATH=/opt/puppetlabs/pdk/private/ruby/2.5.8/lib/ruby/gems/2.5.0:/opt/puppetlabs/pdk/share/cache/ruby/2.5.0:/opt/puppetlabs/pdk/private/puppet/ruby/2.5.0
 
 # Run lint and emit output to json document
-/opt/puppetlabs/pdk/share/cache/ruby/2.5.0/bin/puppet-lint --json manifests > lint_output.json || true
-exit_code=$?
-# Ensure file contains valid JSON if there's no output
-if [[ ! -s lint_output.json ]]; then
+{
+  /opt/puppetlabs/pdk/share/cache/ruby/2.5.0/bin/puppet-lint --json manifests > lint_output.json
+  exit_code=$?
+} || {
+  true
+}
+# Ensure file contains valid JSON if there are no manifests or there's no output
+if [[ $manifests -eq 0 ]] || [[ ! -s lint_output.json ]]; then
   echo 'null' > lint_output.json
 fi
 ruby -e "require 'json'; puts ({ exit_code: $exit_code, manifests: $manifests, lines: $lines, output: JSON.parse(File.read('lint_output.json')) }).to_json" > anubis_output.json

--- a/anubis/entrypoints/puppet-metadata
+++ b/anubis/entrypoints/puppet-metadata
@@ -19,8 +19,13 @@ export PATH=$PATH:/opt/puppetlabs/pdk/private/ruby/2.5.8/bin:/opt/puppetlabs/pdk
 export GEM_PATH=/opt/puppetlabs/pdk/private/ruby/2.5.8/lib/ruby/gems/2.5.0:/opt/puppetlabs/pdk/share/cache/ruby/2.5.0:/opt/puppetlabs/pdk/private/puppet/ruby/2.5.0
 
 # Run metadata-json-lint and emit output to json document
-/opt/puppetlabs/pdk/share/cache/ruby/2.5.0/bin/metadata-json-lint --format json > metadata_output.json || true
-exit_code=$?
+{
+  /opt/puppetlabs/pdk/share/cache/ruby/2.5.0/bin/metadata-json-lint --format json > metadata_output.json
+  exit_code=$?
+} || {
+  true
+}
+
 # Ensure file contains valid JSON if there's no output
 if [[ ! -s metadata_output.json ]]; then
   echo 'null' > metadata_output.json

--- a/anubis/entrypoints/puppet-parser
+++ b/anubis/entrypoints/puppet-parser
@@ -21,8 +21,13 @@ export PATH=$PATH:/opt/puppetlabs/pdk/private/ruby/2.5.8/bin:/opt/puppetlabs/pdk
 export GEM_PATH=/opt/puppetlabs/pdk/private/ruby/2.5.8/lib/ruby/gems/2.5.0:/opt/puppetlabs/pdk/share/cache/ruby/2.5.0:/opt/puppetlabs/pdk/private/puppet/ruby/2.5.0
 
 # Run parser and emit output to json document
-/opt/puppetlabs/pdk/private/puppet/ruby/2.5.0/bin/puppet parser validate --render-as json manifests > parser_output.json || true
-exit_code=$?
+{
+  /opt/puppetlabs/pdk/private/puppet/ruby/2.5.0/bin/puppet parser validate --render-as json manifests > parser_output.json
+  exit_code=$?
+} || {
+  true
+}
+
 # Ensure file contains valid JSON if there's no output
 if [[ ! -s parser_output.json ]]; then
   echo 'null' > parser_output.json


### PR DESCRIPTION
Includes fixing the exit_code capture and accounting for the case where a module release has no manifests directory.