### PR TITLE
(MAINT) Change `update-pdk-release-file.rb` to check multiple sources

### DIFF
--- a/update-pdk-release-file.rb
+++ b/update-pdk-release-file.rb
@@ -4,39 +4,64 @@ require "open-uri"
 require "oga"
 
 NIGHTLIES_HOST = "https://nightlies.puppetlabs.com"
-PDK_BIONIC_BASE = "#{NIGHTLIES_HOST}/apt/pool/bionic/puppet6-nightly/p/pdk"
+PDK_NIGHTLIES_BIONIC_BASE = "#{NIGHTLIES_HOST}/apt/pool/bionic/puppet6-nightly/p/pdk"
+RELEASES_HOST = "https://apt.puppetlabs.com"
+PDK_RELEASES_BIONIC_BASE = "#{RELEASES_HOST}/pool/bionic/puppet6/p/pdk"
 PDK_RELEASE_PKG_REGEX = /^pdk_(?<version>\d+\.\d+\.\d+\.\d+)-1bionic_amd64/
 PDK_NIGHTLY_PKG_REGEX = /^pdk_(?<version>\d+\.\d+\.\d+\.\d+\..*)-1bionic_amd64/
 
 def pdk_nightlies_html
-  URI.parse("#{PDK_BIONIC_BASE}/index_by_lastModified_reverse.html").read
+  URI.parse("#{PDK_NIGHTLIES_BIONIC_BASE}/index_by_lastModified_reverse.html").read
 rescue OpenURI::HTTPError
   nil
 end
 
-def pdk_release_versions
+def pdk_releases_html
+  URI.parse("#{PDK_RELEASES_BIONIC_BASE}/index_by_lastModified_reverse.html").read
+rescue OpenURI::HTTPError
+  nil
+end
+
+def pdk_nightly_versions
   doc = Oga.parse_html(pdk_nightlies_html)
 
   version_map = doc.css('a[href$="deb"]').collect do |el|
-    if matches = el['href'].match(PDK_RELEASE_PKG_REGEX)
+    if matches = el['href'].match(PDK_NIGHTLY_PKG_REGEX)
       {
         :version => matches[:version],
-        :href => "#{PDK_BIONIC_BASE}/#{el['href']}",
-        :type => "release",
-      }
-    elsif matches = el['href'].match(PDK_NIGHTLY_PKG_REGEX)
-      {
-        :version => matches[:version],
-        :href => "#{PDK_BIONIC_BASE}/#{el['href']}",
+        :released_at => Time.parse(el.parent.next_element.text),
+        :href => "#{PDK_NIGHTLIES_BIONIC_BASE}/#{el['href']}",
         :type => "nightly",
       }
+    else
+      nil
     end
   end
 
   version_map.compact
 end
 
-pdk_latest = pdk_release_versions.first || exit(1)
+def pdk_release_versions
+  doc = Oga.parse_html(pdk_releases_html)
+
+  version_map = doc.css('a[href$="deb"]').collect do |el|
+    if matches = el['href'].match(PDK_RELEASE_PKG_REGEX)
+      {
+        :version => matches[:version],
+        :released_at => Time.parse(el.parent.next_element.text),
+        :href => "#{PDK_RELEASES_BIONIC_BASE}/#{el['href']}",
+        :type => "release",
+      }
+    else
+      nil
+    end
+  end
+
+  version_map.compact
+end
+
+all_pdk_releases = (pdk_nightly_versions + pdk_release_versions).sort_by { |ver| ver[:released_at] }.reverse
+pdk_latest = all_pdk_releases.first || exit(1)
 
 File.open('pdk-release.env', 'w+') do |release_file|
   release_file.puts "export PDK_DEB_URL=\"#{pdk_latest[:href]}\""


### PR DESCRIPTION
This commit updates the `update-pdk-release-file.rb` script to check
both `nightlies.puppetlabs.com` and `apt.puppetlabs.com` for PDK
releases and use the actual package file timestamps to determine what
the "latest" release is between the two sources.

Once it has determined the latest release, the rest of the process is
mostly unchanged, it will update the `pdk-release.env` file with the
version and release type of the latest release. The only change is that
for non-nightly releases, the `PDK_DEB_URL` link will point to
`apt.puppetlabs.com` which should be a more stable source than nightlies
where packages can disappear after a while.