### PR TITLE
(MAINT) Update bionic image tag to use date-based tag

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:bionic
+FROM ubuntu:bionic-20210723
 
 WORKDIR /root
 


### PR DESCRIPTION
This updates the tag for the ubuntu bionic image that the pdk-docker image is based on to use a date-based tag instead of the generic OS release tag. This should allow us to pull in updates and security fixes for the base image explicitly, without having to wait for a separate change for the image to be rebuilt.