### PR TITLE
(CONT-910) - Add UTF-8 encoding

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,5 +23,6 @@ RUN pdk new module docker --skip-interview && \
 
 ENV PATH="${PATH}:/opt/puppetlabs/pdk/private/git/bin"
 ENV PDK_DISABLE_ANALYTICS=true
+ENV LANG=C.UTF-8
 
 ENTRYPOINT ["/opt/puppetlabs/pdk/bin/pdk"]


### PR DESCRIPTION
Fixes an issue when running `release prep`.
`ArgumentError: invalid byte sequence in US-ASCII`