### PR TITLE
set base image to ubuntu 24.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:jammy-20230126
+FROM ubuntu:24.04
 
 WORKDIR /root
 


### PR DESCRIPTION
## Summary
Updating the base image tag to the main ubuntu stable tag of 24.04. Drop the timestamp tag, to have always the freshest ubuntu image, to guarantee newest fixes are include upon a build.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [X] Manually verified.
