### PR TITLE
(CAT-1872) Add `linux/arm64` as a build target

### DIFF
--- a/.github/workflows/image-push.yml
+++ b/.github/workflows/image-push.yml
@@ -53,6 +53,7 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: |
             ${{ secrets.AWS_FORGE_ID }}.dkr.ecr.us-west-2.amazonaws.com/anubis:${{ env.TAG }}


### PR DESCRIPTION
Update the GHA build run to publish to `linux/arm64` as well as the default `linux/amd64`.
Changes made according to: https://docs.docker.com/build/ci/github-actions/multi-platform/

## Checklist
- [ ] Manually verified.
