### PR TITLE
(CAT-1872) Update auto release to publish ARM64 in addition to AMD64

### DIFF
--- a/.github/workflows/image-push.yml
+++ b/.github/workflows/image-push.yml
@@ -53,6 +53,7 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: |
             ${{ secrets.AWS_FORGE_ID }}.dkr.ecr.us-west-2.amazonaws.com/anubis:${{ env.TAG }}

--- a/install-pdk-release.sh
+++ b/install-pdk-release.sh
@@ -3,6 +3,12 @@
 set +x
 
 source pdk-release.env
+# if uname -m = aarch64, then use arm64, otherwise use amd64
+if [ "$(uname -m)" = "aarch64" ]; then
+  PDK_DEB_URL="${PDK_DEB_URL_ARM64}"
+else
+  PDK_DEB_URL="${PDK_DEB_URL_AMD64}"
+fi
 
 curl --fail -L -o \
   "pdk.deb" \

--- a/pdk-release.env
+++ b/pdk-release.env
@@ -1,3 +1,4 @@
-export PDK_DEB_URL="https://apt.puppetlabs.com/pool/jammy/puppet-tools/p/pdk/pdk_3.2.0.1-1jammy_amd64.deb"
+export PDK_DEB_URL_ARM64="https://apt.puppetlabs.com/pool/jammy/puppet-tools/p/pdk/pdk_3.2.0.1-1jammy_arm64.deb"
+export PDK_DEB_URL_AMD64="https://apt.puppetlabs.com/pool/jammy/puppet-tools/p/pdk/pdk_3.2.0.1-1jammy_amd64.deb"
 export PDK_VERSION="3.2.0.1"
 export PDK_RELEASE_TYPE="release"

--- a/update-pdk-release-file.rb
+++ b/update-pdk-release-file.rb
@@ -1,3 +1,4 @@
+#!/usr/bin/env ruby
 # frozen_string_literal: true
 
 require "open-uri"
@@ -61,11 +62,20 @@ def pdk_release_versions
   version_map.compact
 end
 
-all_pdk_releases = (pdk_nightly_versions + pdk_release_versions).sort_by { |ver| ver[:released_at] }.reverse
-pdk_latest = all_pdk_releases.first || exit(1)
+# Retrieve all PDK releases
+all_pdk_releases = (pdk_nightly_versions + pdk_release_versions)
+
+# Find the newest ARM PDK release
+all_arm_releases = all_pdk_releases.select{ |i| i[:href].match(/arm64/) }.sort_by { |ver| ver[:released_at] }.reverse
+arm_latest = all_arm_releases.first || exit(1)
+
+# Find the newest AMD PDK release
+all_amd_releases = all_pdk_releases.select{ |i| i[:href].match(/amd64/) }.sort_by { |ver| ver[:released_at] }.reverse
+amd_latest = all_amd_releases.first || exit(1)
 
 File.open('pdk-release.env', 'w+') do |release_file|
-  release_file.puts "export PDK_DEB_URL=\"#{pdk_latest[:href]}\""
+  release_file.puts "export PDK_DEB_URL_ARM64=\"#{arm_latest[:href]}\""
+  release_file.puts "export PDK_DEB_URL_AMD64=\"#{amd_latest[:href]}\""
   release_file.puts "export PDK_VERSION=\"#{pdk_latest[:version]}\""
   release_file.puts "export PDK_RELEASE_TYPE=\"#{pdk_latest[:type]}\""
 end


### PR DESCRIPTION
Updates the code so that ARM64 images are created alongside the default AMD64 images and published to the docker hub.
Note: Waiting on release next release of PDK

## Checklist
- [ ] Manually verified.
